### PR TITLE
Change big-burner-generator.cfg encoding from Shift_JIS to UTF-8.

### DIFF
--- a/locale/ja/big-burner-generator.cfg
+++ b/locale/ja/big-burner-generator.cfg
@@ -1,8 +1,8 @@
 [item-name]
-big-burner-generator=‹‘åƒo[ƒi[”­“d‹@
+big-burner-generator=å·¨å¤§ãƒãƒ¼ãƒŠãƒ¼ç™ºé›»æ©Ÿ
 [item-description]
-big-burner-generator=”R—¿‚ğ”R‚â‚µ‚Ä”­“d‚µ‚Ü‚·B
+big-burner-generator=ç‡ƒæ–™ã‚’ç‡ƒã‚„ã—ã¦ç™ºé›»ã—ã¾ã™ã€‚
 [entity-name]
-big-burner-generator=‹‘åƒo[ƒi[”­“d‹@
+big-burner-generator=å·¨å¤§ãƒãƒ¼ãƒŠãƒ¼ç™ºé›»æ©Ÿ
 [technology-name]
-big-burner-generator=‹‘åƒo[ƒi[”­“d‹@
+big-burner-generator=å·¨å¤§ãƒãƒ¼ãƒŠãƒ¼ç™ºé›»æ©Ÿ


### PR DESCRIPTION
Fix mods not loading in Japanese environment.